### PR TITLE
🧪 [testing improvement] Add missing error path tests for apply_sharpen

### DIFF
--- a/tests/test_image_filters.py
+++ b/tests/test_image_filters.py
@@ -337,12 +337,20 @@ class TestImageBlurAndSharpen(unittest.TestCase):
         self.assertGreater(sharp_gradient, blur_gradient)
 
         # Test invalid values
-        with self.assertRaises(TypeError):
-            apply_sharpen(self.test_image, "invalid")
-        with self.assertRaises(ValueError):
-            apply_sharpen(self.test_image, -1)
         with self.assertRaises(ValueError):
             apply_sharpen(self.test_image, 101)
+        with self.assertRaises(ValueError):
+            apply_sharpen(self.test_image, -1)
+        with self.assertRaises(TypeError):
+            apply_sharpen(self.test_image, "invalid")
+        with self.assertRaises(TypeError):
+            apply_sharpen(self.test_image, 50.5)
+        with self.assertRaises(TypeError):
+            apply_sharpen(self.test_image, [50])
+        with self.assertRaises(TypeError):
+            apply_sharpen(self.test_image, {"value": 50})
+        with self.assertRaises(TypeError):
+            apply_sharpen(self.test_image, None)
 
 
 class TestImageColorOps(unittest.TestCase):


### PR DESCRIPTION
This PR improves the test coverage for the `apply_sharpen` function in `image_filters.py` by adding missing error path tests for invalid types.

### 🎯 What:
Addressed a testing gap where `apply_sharpen` was not fully tested for invalid parameter types.

### 📊 Coverage:
The following scenarios are now covered:
- Passing a float as `sharpness` (raises `TypeError`)
- Passing a list as `sharpness` (raises `TypeError`)
- Passing a dictionary as `sharpness` (raises `TypeError`)
- Passing `None` as `sharpness` (raises `TypeError`)
- Re-verified existing `ValueError` and string-based `TypeError` tests.

### ✨ Result:
The reliability of the `apply_sharpen` function is increased by ensuring its input validation logic is thoroughly verified. Verified the changes using a mock-based test suite to circumvent environment limitations.

---
*PR created automatically by Jules for task [4421804348777859805](https://jules.google.com/task/4421804348777859805) started by @dealien*