### PR TITLE
Fix terminal progress timers and CLI output formatting

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -294,7 +294,9 @@ def process_images_and_save(images_data, ordered_operations, cli_args):
         # Pre-add all image tasks (hidden) so they appear above Total
         image_tasks = []
         for original_name, _ in images_data:
-            task_id = progress.add_task(original_name, total=image_total, visible=False)
+            task_id = progress.add_task(
+                original_name, total=image_total, visible=False, start=False
+            )
             image_tasks.append(task_id)
 
         # Add Total last so it stays at the bottom
@@ -302,6 +304,7 @@ def process_images_and_save(images_data, ordered_operations, cli_args):
 
         for i, (original_name, image_path) in enumerate(images_data, 1):
             image_task = image_tasks[i - 1]
+            progress.start_task(image_task)
             progress.update(image_task, visible=True)
 
             # Calculate elapsed time for log marker
@@ -312,7 +315,7 @@ def process_images_and_save(images_data, ordered_operations, cli_args):
             progress.console.print(
                 f"  [bold bright_yellow]▸ [{i}/{total_images}][/]  "
                 f"[bold bright_white]{original_name}[/]  "
-                f"[bright_cyan][{elapsed_now: >4.1f}s ][/]"
+                f"[bright_cyan][{elapsed_now:>5.1f}s ][/]"
             )
             progress.console.print(
                 Rule(style="dim white"),
@@ -437,16 +440,9 @@ def process_images_and_save(images_data, ordered_operations, cli_args):
     cli_str = " ".join(cli_args_list)
 
     if cli_str:
-        cli_panel = Panel(
-            f"> python main.py {cli_str}",
-            title="💻  Equivalent CLI Command",
-            title_align="left",
-            border_style="bright_blue",
-            box=box.ROUNDED,
-            padding=(1, 2),
-        )
         console.print()
-        console.print(cli_panel)
+        console.print("💻  [bold bright_cyan]Equivalent CLI Command[/]")
+        console.print(f"[bright_yellow]> python main.py {cli_str}[/]")
 
     # ── Results Table ──────────────────────────────────
     console.print()


### PR DESCRIPTION
This PR addresses three terminal output refinements in the interactive interactive image processing menu:
1. Fixes the progress bar timers to display the individual processing time for each image rather than the total processing up to that point. This was done by passing `start=False` to `add_task` and then explicitly calling `progress.start_task(image_task)` when each image begins processing.
2. Fixes the inconsistent spacing in the log timers (e.g. `[ 0.0s ]` vs `[14.0s ]`) by updating the format specifier to correctly pad the text, resulting in a consistent look (e.g. `[  0.0s ]` vs `[ 14.0s ]`).
3. Formats the "Equivalent CLI Command" output to no longer use a bordered Panel, preventing issues with copy/pasting wrapped commands from the terminal. The command is still styled with bright colors.

---
*PR created automatically by Jules for task [17700853749163397454](https://jules.google.com/task/17700853749163397454) started by @dealien*