### PR TITLE
🧪 [testing improvement] Add unit tests for `handle_border` error paths

### DIFF
--- a/tests/test_handle_border_error_handling.py
+++ b/tests/test_handle_border_error_handling.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+import processing
+
+
+class TestHandleBorderErrorHandling(unittest.TestCase):
+    @patch("processing.console.print")
+    @patch("processing.apply_border")
+    def test_handle_border_value_error(self, mock_apply_border, mock_console_print):
+        # Setup
+        image = MagicMock()
+        args = SimpleNamespace()
+
+        # Test Case: Invalid thickness (non-int)
+        values = ["invalid_thickness", "black", "expand"]
+        result = processing.handle_border(image, "test.png", values, args)
+
+        # Verify
+        mock_console_print.assert_called_with(
+            "  [bright_red]✗[/] [red]Invalid border arguments: ['invalid_thickness', 'black', 'expand']. Error: invalid literal for int() with base 10: 'invalid_thickness'[/]"
+        )
+        self.assertEqual(result, image)
+        mock_apply_border.assert_not_called()
+
+    @patch("processing.console.print")
+    @patch("processing.apply_border")
+    def test_handle_border_index_error(self, mock_apply_border, mock_console_print):
+        # Setup
+        image = MagicMock()
+        args = SimpleNamespace()
+
+        # Test Case: Missing position
+        values = ["10", "black"]
+        result = processing.handle_border(image, "test.png", values, args)
+
+        # Verify
+        mock_console_print.assert_called_with(
+            "  [bright_red]✗[/] [red]Invalid border arguments: ['10', 'black']. Error: list index out of range[/]"
+        )
+        self.assertEqual(result, image)
+        mock_apply_border.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The untested error paths (`ValueError` and `IndexError`) in `processing.py:handle_border` when processing incorrect scale arguments.
📊 **Coverage:** Test coverage handles incorrect invalid integer values for border thickness (`ValueError`), as well as missing positional arguments (`IndexError`).
✨ **Result:** Increased testing confidence around edge cases in `handle_border` to prevent unhandled application failure and guarantee correct logging messages are rendered to the console.

---
*PR created automatically by Jules for task [12488740853067291706](https://jules.google.com/task/12488740853067291706) started by @dealien*