### PR TITLE
🧪 Add test for apply_color_balance with RGBA images

### DIFF
--- a/tests/test_image_filters.py
+++ b/tests/test_image_filters.py
@@ -385,6 +385,26 @@ class TestImageColorOps(unittest.TestCase):
         # 100 * 10 = 1000 -> clamped to 255
         self.assertEqual(red_enhanced.getpixel((0, 0))[0], 255)
 
+    def test_color_balance_rgba(self):
+        # Create an RGBA image for testing
+        rgba_image = self.test_image.copy().convert("RGBA")
+        # Set a semi-transparent alpha channel
+        alpha = Image.new("L", rgba_image.size, 128)
+        rgba_image.putalpha(alpha)
+
+        # Enhance Red
+        red_enhanced = apply_color_balance(rgba_image, 2.0, 1.0, 1.0)
+
+        # Check that the image is still RGBA
+        self.assertEqual(red_enhanced.mode, "RGBA")
+
+        # Check that the RGB values are correctly scaled
+        self.assertEqual(red_enhanced.getpixel((0, 0))[:3], (200, 100, 100))
+
+        # Check that the alpha channel is preserved
+        _, _, _, new_alpha = red_enhanced.split()
+        self.assertEqual(list(new_alpha.getdata()), list(alpha.getdata()))
+
     def test_posterize(self):
         # Create a gradient image
         img = Image.new("RGB", (256, 1))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the edge case in `apply_color_balance` where the input image has 4 or more bands (such as an RGBA image).
📊 **Coverage:** The new test `test_color_balance_rgba` validates that when an RGBA image is processed, the output retains the "RGBA" mode, correctly applies the RGB scaling factors, and leaves the alpha channel unchanged.
✨ **Result:** Test coverage for `apply_color_balance` has been improved, explicitly verifying the 4+ band merging logic and ensuring no regressions in alpha channel handling.

---
*PR created automatically by Jules for task [1045326233784190778](https://jules.google.com/task/1045326233784190778) started by @dealien*