### PR TITLE
🧪 Test apply_color_balance with 4+ bands

### DIFF
--- a/tests/test_image_filters.py
+++ b/tests/test_image_filters.py
@@ -405,6 +405,22 @@ class TestImageColorOps(unittest.TestCase):
         _, _, _, new_alpha = red_enhanced.split()
         self.assertEqual(list(new_alpha.getdata()), list(alpha.getdata()))
 
+    def test_apply_color_balance_4_plus_bands(self):
+        # Create an RGBA image for testing 4+ bands edge case
+        rgba_image = self.test_image.copy().convert("RGBA")
+        alpha = Image.new("L", rgba_image.size, 100)
+        rgba_image.putalpha(alpha)
+
+        # Enhance Color
+        color_balanced = apply_color_balance(rgba_image, 1.5, 1.0, 1.0)
+
+        # Check output mode
+        self.assertEqual(color_balanced.mode, "RGBA")
+
+        # Verify alpha channel is preserved
+        _, _, _, result_alpha = color_balanced.split()
+        self.assertEqual(list(result_alpha.getdata()), list(alpha.getdata()))
+
     def test_posterize(self):
         # Create a gradient image
         img = Image.new("RGB", (256, 1))


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Addressed an untested edge case in `apply_color_balance` in `image_filters.py` where the output mode and alpha channel for an image with 4+ bands were not explicitly validated by a targeted unit test.

📊 **Coverage:** What scenarios are now tested
A new test `test_apply_color_balance_4_plus_bands` was created to explicitly verify that when an RGBA image is passed to `apply_color_balance`, the output mode is correctly identified as "RGBA" and the alpha channel correctly persists without corruption.

✨ **Result:** The improvement in test coverage
Test coverage across `tests/test_image_filters.py` has been explicitly verified, ensuring 100% test pass rate with improved confidence against regression bugs for alpha channel extraction in color balance modifications.

---
*PR created automatically by Jules for task [13466467058244055340](https://jules.google.com/task/13466467058244055340) started by @dealien*