### PR TITLE
📝 Scribe: [doc improvement] document default Base Images search path

### DIFF
--- a/src/image_converter/file_management.py
+++ b/src/image_converter/file_management.py
@@ -18,6 +18,9 @@ import shutil
 def move_images_to_subdirectory(subdirectory_name: str):
     """Moves all image files from the current directory to a specified subdirectory.
 
+    Typically used to move images into the 'Base Images' directory, which is the
+    default search path for image processing operations.
+
     Args:
         subdirectory_name (str): The name of the subdirectory to create and move
             the images into.

--- a/src/image_converter/main.py
+++ b/src/image_converter/main.py
@@ -51,7 +51,8 @@ def main():
 
     Parses command-line arguments and executes the specified image processing
     pipeline. If no arguments are provided or the `--menu` flag is used, it
-    launches the interactive menu interface.
+    launches the interactive menu interface. By default, the program searches
+    for images in the `Base Images/` directory if no specific file path is given.
     """
 
     # If --menu is used or no arguments are provided, start the menu.
@@ -71,7 +72,8 @@ def main():
         type=str,
         nargs="?",
         default=None,
-        help='The image file or pattern to process (e.g., "input.jpg", "images/*.png").',
+        help='The image file or pattern to process (e.g., "input.jpg", "images/*.png"). '
+        'If omitted or set to "*", searches in the "Base Images/" directory by default.',
     )
     parser.add_argument(
         "--menu",


### PR DESCRIPTION
## What
This PR updates the internal documentation and CLI help string to clearly state that the program searches for images in the `Base Images/` directory by default.

## Why
To make it clear to users and developers where the tool looks for images if no explicit path is provided. The user request was to "Update the docs to mention where the program searches for images." Since `README.md` and `docs/` already mention this, the missing documentation was in the code docstrings and the `--help` output.

## Preview
```bash
image-converter --help
...
positional arguments:
  file                  The image file or pattern to process (e.g., "input.jpg", "images/*.png"). If omitted or set to "*", searches in the "Base Images/" directory by default.
```

---
*PR created automatically by Jules for task [10148903006866831954](https://jules.google.com/task/10148903006866831954) started by @dealien*