### PR TITLE
🎨 Palette: Add helpful call-to-action to empty pipeline state

### DIFF
--- a/src/image_converter/rich_menu.py
+++ b/src/image_converter/rich_menu.py
@@ -159,7 +159,10 @@ def render_combined_menu(images_data, operations, extra_args):
     cli_args_list = []
 
     if not operations:
-        pipeline_content.append("  (Empty)\n", style="dim italic")
+        pipeline_content.append(
+            "  (Empty - Select operations below to build your pipeline)\n",
+            style="dim italic",
+        )
     else:
         for i, op in enumerate(operations):
             # Formats beautifully with numbers


### PR DESCRIPTION
💡 **What:** Added a helpful call-to-action to the empty pipeline state in the interactive terminal UI.
🎯 **Why:** To improve user guidance when first launching the tool. The previous `(Empty)` message was a bit abrupt and didn't provide immediate context on what the user should do next to build their pipeline. The new message guides them intuitively toward the operations menu.
📸 **Before/After:**
- Before: `  (Empty)`
- After: `  (Empty - Select operations below to build your pipeline)`
♿ **Accessibility:** This improves cognitive accessibility by explicitly stating the expected user action rather than relying solely on visual exploration or assumed knowledge of the interface.

---
*PR created automatically by Jules for task [16487350448506438931](https://jules.google.com/task/16487350448506438931) started by @dealien*