### PR TITLE
📝 Scribe: Fix incorrect Pillow type hints in remove_background.py

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,4 @@
+
+## 2025-05-15 - Pillow Type Hints for Generic Images
+**Learning:** Using `ImageFile` as a generic type hint in Pillow causes confusion for tools expecting general image processing types, as `ImageFile` is actually a specific subclass used for lazy-loading image files, not the generic image object.
+**Action:** When adding type hints to functions accepting Pillow images (like filters, resizing, background removal), always use `PIL.Image.Image` as the standard type hint for an image object unless specifically relying on the lazy-loading properties of `ImageFile`.

--- a/src/image_converter/remove_background.py
+++ b/src/image_converter/remove_background.py
@@ -5,20 +5,22 @@ and trim empty space from the resulting image.
 """
 
 from rembg import remove
-from PIL import Image, ImageOps, ImageChops, ImageFile
+from PIL import Image, ImageOps, ImageChops
 
 
-def remove_background(image_input: ImageFile, opt_border_width: int = 0):
+def remove_background(
+    image_input: Image.Image, opt_border_width: int = 0
+) -> Image.Image:
     """Remove the background from an image.
 
     Args:
-        image_input (ImageFile): The image to modify.
+        image_input (Image.Image): The image to modify.
         opt_border_width (int, optional): The number of pixels to be added and later removed from the border. Defaults to 0.
 
     Returns:
         Image.Image: The image with its background removed and trimmed.
-    """
 
+    """
     # Add white border
     image_input = ImageOps.expand(image_input, border=int(opt_border_width))
     # Removes background
@@ -28,14 +30,15 @@ def remove_background(image_input: ImageFile, opt_border_width: int = 0):
     return output
 
 
-def trim(image: ImageFile):
+def trim(image: Image.Image) -> Image.Image:
     """Trim empty background space from an image by finding its bounding box.
 
     Args:
-        image (ImageFile): The image to be trimmed.
+        image (Image.Image): The image to be trimmed.
 
     Returns:
         Image.Image: The cropped image if a bounding box was found, otherwise the original image.
+
     """
     bg = Image.new(image.mode, image.size, image.getpixel((0, 0)))
     diff = ImageChops.difference(image, bg)


### PR DESCRIPTION
**💡 What:**
Updated the type hints in `src/image_converter/remove_background.py` to use `Image.Image` instead of `ImageFile`. Also added missing return type hints (`-> Image.Image`) to both `remove_background` and `trim` functions, and resolved two specific `ruff` docstring style warnings (D202, D413). Added a new entry to the `.jules/scribe.md` journal documenting this finding.

**🎯 Why:**
The previous type hint `ImageFile` is a specific lazy-loading subclass within Pillow, which is not the standard or correct generic type to use for image processing arguments. Using `Image.Image` provides clear, accurate type checking for contributors using this codebase. Correcting the return types and `ruff` warnings further improves the code's documentation and adherence to standard styles.

**📖 Preview:**
```python
def remove_background(image_input: Image.Image, opt_border_width: int = 0) -> Image.Image:
    """Remove the background from an image.
...
def trim(image: Image.Image) -> Image.Image:
    """Trim empty background space from an image by finding its bounding box.
```

---
*PR created automatically by Jules for task [6645925640599094864](https://jules.google.com/task/6645925640599094864) started by @dealien*