### PR TITLE
📝 Scribe: [doc improvement] Fix ImageFile type hints

### DIFF
--- a/src/image_converter/flip_image.py
+++ b/src/image_converter/flip_image.py
@@ -3,14 +3,14 @@
 Provides a function to flip an image horizontally, vertically, or both.
 """
 
-from PIL import Image, ImageFile
+from PIL import Image
 
 
-def flip_image(image_input: ImageFile, direction: str):
+def flip_image(image_input: Image.Image, direction: str):
     """Flip an image horizontally, vertically, or both.
 
     Args:
-        image_input (ImageFile): The image to modify.
+        image_input (Image.Image): The image to modify.
         direction (str): The direction to flip the image. Can be 'horizontal', 'vertical', or 'both'.
 
     Returns:

--- a/src/image_converter/scale_image.py
+++ b/src/image_converter/scale_image.py
@@ -4,7 +4,7 @@ Handles scaling by a factor or to a specific dimensions, supporting various
 resampling filters such as nearest, bilinear, bicubic, and lanczos.
 """
 
-from PIL import Image, ImageFile
+from PIL import Image
 
 RESAMPLE_FILTERS = {
     "nearest": Image.Resampling.NEAREST,
@@ -17,7 +17,7 @@ MAX_TOTAL_PIXELS = 100000000  # 100MP
 
 
 def scale_image(
-    image_input: ImageFile,
+    image_input: Image.Image,
     scale_factor: float = None,
     new_size: tuple = None,
     resample_filter: str = "bilinear",
@@ -25,7 +25,7 @@ def scale_image(
     """Scale an image up or down, preserving aspect ratio.
 
     Args:
-        image_input (ImageFile): The image to modify.
+        image_input (Image.Image): The image to modify.
         scale_factor (float, optional): The factor to scale the image by. Defaults to None.
         new_size (tuple, optional): The new size of the image as a tuple (width, height) to fit within. Defaults to None.
         resample_filter (str, optional): The resampling filter to use. Defaults to "bilinear".


### PR DESCRIPTION
💡 **What:** Replaced the `ImageFile` type hint with `Image.Image` in `flip_image.py` and `scale_image.py`, and updated their corresponding docstrings. Removed the now unused `ImageFile` import from both files.

🎯 **Why:** `ImageFile` is a specific subclass in Pillow used specifically for lazy-loading images from files. Using it as a generic type hint causes confusion for tools and developers expecting generic image processing types. `Image.Image` is the correct base class encompassing all image objects.

📖 **Preview:**
```python
def flip_image(image_input: Image.Image, direction: str):
    """Flip an image horizontally, vertically, or both.

    Args:
        image_input (Image.Image): The image to modify.
```

---
*PR created automatically by Jules for task [7017991101783703992](https://jules.google.com/task/7017991101783703992) started by @dealien*