### PR TITLE
ci: add pip caching to github actions

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: "pip"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
+        cache: "pip"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Add the `cache: "pip"` argument to the `actions/setup-python@v5` steps in both the mkdocs and pytest GitHub Actions workflows. This caches pip dependencies, speeding up subsequent workflow runs and reducing network overhead.

---
*PR created automatically by Jules for task [7743064593509650561](https://jules.google.com/task/7743064593509650561) started by @dealien*