### PR TITLE
🧪 Add test for handle_grayscale

### DIFF
--- a/tests/test_operation_handlers.py
+++ b/tests/test_operation_handlers.py
@@ -37,6 +37,19 @@ class TestOperationHandlers(unittest.TestCase):
         self.assertEqual(result, "no_bg_image")
 
     @patch("image_converter.processing.console.print")
+    @patch("image_converter.processing.grayscale")
+    def test_handle_grayscale(self, mock_grayscale, mock_print):
+        mock_grayscale.return_value = "grayscale_image"
+        values = []
+        result = processing.handle_grayscale(
+            self.image, self.image_name, values, self.args
+        )
+
+        mock_print.assert_called_once()
+        mock_grayscale.assert_called_once_with(self.image)
+        self.assertEqual(result, "grayscale_image")
+
+    @patch("image_converter.processing.console.print")
     @patch("image_converter.processing.adjust_brightness")
     def test_handle_brightness(self, mock_adjust, mock_print):
         mock_adjust.return_value = "bright_image"


### PR DESCRIPTION
🎯 **What:** 
Added a missing unit test for the `handle_grayscale` function in `processing.py` to ensure it correctly delegates to the underlying filter and handles console output.

📊 **Coverage:**
The new test (`test_handle_grayscale` in `tests/test_operation_handlers.py`) covers the happy path for the `handle_grayscale` delegation function by mocking both `image_converter.processing.console.print` and `image_converter.processing.grayscale`. It asserts that the underlying `grayscale` filter is correctly called once with the provided image, that the console log is printed, and that the function appropriately returns the result of the filter.

✨ **Result:**
Test coverage for `processing.py`'s operation handlers is improved. The `handle_grayscale` function is now verified against its expected delegation behavior, reducing the risk of regressions during future refactors or updates to the processing pipeline.

---
*PR created automatically by Jules for task [6556261186123817076](https://jules.google.com/task/6556261186123817076) started by @dealien*