### PR TITLE
🧪 Add exact console logging test for handle_flip

### DIFF
--- a/tests/test_operation_handlers.py
+++ b/tests/test_operation_handlers.py
@@ -19,7 +19,9 @@ class TestOperationHandlers(unittest.TestCase):
         values = ["horizontal"]
         result = processing.handle_flip(self.image, self.image_name, values, self.args)
 
-        mock_print.assert_called_once()
+        mock_print.assert_called_once_with(
+            "  [bright_yellow]›[/] [yellow]Flipping horizontal...[/]"
+        )
         mock_flip.assert_called_once_with(self.image, "horizontal")
         self.assertEqual(result, "flipped_image")
 


### PR DESCRIPTION
🎯 **What:** The previous test for `handle_flip` in `tests/test_operation_handlers.py` only checked that `console.print` was called once, but not what it printed. This adds a specific assertion to verify it correctly logs `Flipping [direction]...`.
  
📊 **Coverage:** Specifically tested the console formatting string `"  [bright_yellow]›[/] [yellow]Flipping horizontal...[/]"` matching the output on `processing.py` line 101.

✨ **Result:** Test coverage for this edge case is strictly verified without introducing regressions, keeping the codebase safer for refactoring.

---
*PR created automatically by Jules for task [64677529549281871](https://jules.google.com/task/64677529549281871) started by @dealien*