### PR TITLE
🧹 Remove commented out text buffer access in menu.py

### DIFF
--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -54,9 +54,6 @@ def _ask_text(
     def get_prompt_text():
         # Dynamic prompt generation based on current input buffer
         try:
-            # text = get_app().current_buffer.text  # This works in full app
-            # For prompt() shortcut, we might need a safer access if app not ready
-            # But prompt() initializes app before rendering.
             text = get_app().current_buffer.text
         except Exception:
             text = ""


### PR DESCRIPTION
🎯 **What:** Removed unused and commented-out code in the `get_prompt_text` function within `src/image_converter/menu.py`.
💡 **Why:** This improves maintainability and readability by eliminating dead code and redundant comments that no longer serve a purpose.
✅ **Verification:** Manually verified the code change, ran `ruff check` and `ruff format --check`, and received a positive code review.
✨ **Result:** A cleaner and more maintainable `get_prompt_text` function.

---
*PR created automatically by Jules for task [4012574790721790043](https://jules.google.com/task/4012574790721790043) started by @dealien*