### PR TITLE
🔒 Fix decompression bomb vulnerability in image processing and metadata extraction

### DIFF
--- a/src/image_converter/processing.py
+++ b/src/image_converter/processing.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 
 from PIL import Image
+
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
@@ -81,6 +82,9 @@ class StyledTimeElapsedColumn(TimeElapsedColumn):
 
 
 console = Console()
+
+# Set a safe limit for image size to prevent decompression bomb attacks (100MP)
+Image.MAX_IMAGE_PIXELS = 100_000_000
 
 # --- Operation Handlers ---
 

--- a/src/image_converter/rich_menu.py
+++ b/src/image_converter/rich_menu.py
@@ -18,6 +18,9 @@ from rich.console import Console
 
 console = Console()
 
+# Set a safe limit for image size to prevent decompression bomb attacks (100MP)
+Image.MAX_IMAGE_PIXELS = 100_000_000
+
 
 def _get_image_metadata(path: str) -> tuple[str, str, str]:
     """Retrieves basic metadata for an image file.

--- a/tests/test_security_limits.py
+++ b/tests/test_security_limits.py
@@ -1,0 +1,27 @@
+import unittest
+import importlib
+
+
+class TestSecurityLimits(unittest.TestCase):
+    def test_max_image_pixels_setting(self):
+        """Test that PIL.Image.MAX_IMAGE_PIXELS is set to a safe limit."""
+        import PIL.Image
+
+        PIL.Image.MAX_IMAGE_PIXELS = 0  # reset
+
+        # Importing will set it
+        import image_converter.rich_menu
+
+        importlib.reload(image_converter.rich_menu)
+
+        self.assertEqual(PIL.Image.MAX_IMAGE_PIXELS, 100000000)
+
+        PIL.Image.MAX_IMAGE_PIXELS = 0
+        import image_converter.processing
+
+        importlib.reload(image_converter.processing)
+        self.assertEqual(PIL.Image.MAX_IMAGE_PIXELS, 100000000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability where image files could be opened without a defined pixel limit, potentially leading to decompression bomb (Denial of Service) attacks.

⚠️ **Risk:** A maliciously crafted image with a large declared size but small file size could exhaust system memory when opened for metadata extraction or processing.

🛡️ **Solution:** `PIL.Image.MAX_IMAGE_PIXELS` is now explicitly set to `100_000_000` (100MP) in both `src/image_converter/rich_menu.py` (for metadata) and `src/image_converter/processing.py` (for the main processing pipeline). This aligns with existing security guards in the project. A new test `tests/test_security_limits.py` ensures these limits are correctly applied upon module import.

---
*PR created automatically by Jules for task [229914259262320052](https://jules.google.com/task/229914259262320052) started by @dealien*