### PR TITLE
🧹 Remove unnecessary commented-out code

### DIFF
--- a/src/image_converter/file_management.py
+++ b/src/image_converter/file_management.py
@@ -59,8 +59,6 @@ def move_images_to_subdirectory(subdirectory_name: str):
                     console.print(
                         f"[bright_green]Moved:[/] {filename} to {subdirectory_name}"
                     )  # Informative message
-                # else: # Optional: if you want to see which files were SKIPPED
-                #    console.print(f"[dim yellow]Skipped (not an image): {filename}[/]")
 
     except Exception as e:  # Handle potential errors
         console.print(f"[red]An error occurred: {e}[/]")

--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -801,7 +801,6 @@ def select_manipulations(images_data):
 
             if op_details:
                 selected_operations.append(op_details)
-                # print(f"Added '{manip['name']}'.") # Status is now implied by UI update
 
     return selected_operations, extra_args
 


### PR DESCRIPTION
🎯 **What:** Removed an unused commented-out `print` statement in `src/image_converter/menu.py` (line 804) and another block of unused commented-out code (an `else` block containing a `console.print`) in `src/image_converter/file_management.py` (lines 62-63).

💡 **Why:** Removing dead, commented-out code reduces clutter, improves overall readability, and makes the codebase easier to maintain. These remnants were no longer needed.

✅ **Verification:** Verified that the relevant commented-out statements were deleted using `cat` and `grep`. Ran the full test suite via `python -m pytest` and confirmed all 157 tests passed successfully, ensuring no functionality was broken. Requested an automated code review which verified the changes were trivial and completely safe.

✨ **Result:** A cleaner codebase with less visual noise, leading to improved code health and readability without altering any functionality.

---
*PR created automatically by Jules for task [219549537975637868](https://jules.google.com/task/219549537975637868) started by @dealien*