### PR TITLE
🎨 Palette: Add keyboard shortcuts to CLI confirmations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2025-04-01 - Added loading spinner during parallel metadata fetching in rich menu
 **Learning:** During parallel metadata fetching of image files using `ThreadPoolExecutor` within the `run_image_selector` function, the UI could appear to hang for large images or large directories, offering a poor UX for the user.
 **Action:** Always consider the UX impact of blocking IO-bound operations when starting interactive prompts. Wrap these operations in a visual loading indicator such as the `rich` `console.status` spinner, to signal to users that work is occurring in the background.
+
+## 2024-05-24 - explicit keyboard shortcuts for confirm prompts
+**Learning:** questionary.confirm does not display keyboard hints or handle Ctrl+C explicitly out-of-the-box. We must provide explicit `instruction` strings and manually check for `None` to raise KeyboardInterrupt.
+**Action:** Add INSTR_CONFIRM constant and check for None on all confirm calls.

--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Optional
 from .main import console
 
 INSTR_SELECT = "(Use arrow keys to navigate, Enter to select, Ctrl+C to cancel)"
+INSTR_CONFIRM = "(y/n, Enter to confirm, Ctrl+C to cancel)"
 INSTR_MULTI_SELECT = (
     "(Use Space to select/deselect, Enter to confirm, Ctrl+C to cancel)"
 )
@@ -761,8 +762,14 @@ def select_images() -> list[str]:
             return selected_paths
 
         confirm = questionary.confirm(
-            "No images selected. Re-select images?", default=True
+            "No images selected. Re-select images?",
+            default=True,
+            instruction=INSTR_CONFIRM,
         ).ask()
+
+        if confirm is None:
+            raise KeyboardInterrupt
+
         if not confirm:
             return []
 
@@ -870,8 +877,14 @@ def select_manipulations(
         if selection == "PROCESS":
             if not selected_operations:
                 confirm = questionary.confirm(
-                    "Pipeline is empty. Process anyway?", default=False
+                    "Pipeline is empty. Process anyway?",
+                    default=False,
+                    instruction=INSTR_CONFIRM,
                 ).ask()
+
+                if confirm is None:
+                    raise KeyboardInterrupt
+
                 if not confirm:
                     continue
 
@@ -911,8 +924,14 @@ def select_manipulations(
                     output_qualities.append(int(q_str) if q_str else 90)
 
             flatten_confirm = questionary.confirm(
-                "Flatten transparent backgrounds?", default=False
+                "Flatten transparent backgrounds?",
+                default=False,
+                instruction=INSTR_CONFIRM,
             ).ask()
+
+            if flatten_confirm is None:
+                raise KeyboardInterrupt
+
             if flatten_confirm:
                 flatten_color = _ask_text(
                     "Background color for flattening (Name or Hex)", default_val="white"


### PR DESCRIPTION
💡 **What**: Added explicit instructional text for interactive CLI confirmation prompts and manually handled `None` state (returned when a user types `Ctrl+C`) to safely exit via `KeyboardInterrupt` rather than silently assuming an empty/false response.

🎯 **Why**: Improves UX by explicitly showing keyboard mapping defaults on prompts, and properly propagating standard application exits when terminal abort sequences are received.

♿ **Accessibility**: Improves clarity for terminal users relying on standard cancel patterns (Ctrl+C).

---
*PR created automatically by Jules for task [13915102690841374929](https://jules.google.com/task/13915102690841374929) started by @dealien*