### PR TITLE
🎨 Palette: Add full keyboard navigation hints to multi-select prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -24,3 +24,6 @@
 ## 2025-04-06 - Explicit Instruction Strings for questionary.confirm
 **Learning:** By default, `questionary.confirm` prompts do not display any keyboard shortcut instructions, leaving users unaware of options like `Ctrl+C` to cancel or `y/n` for explicit choices.
 **Action:** Explicitly provide an `instruction` string constant (e.g., `(y/n, Enter to confirm, Ctrl+C to cancel)`) to all `questionary.confirm` calls to surface hidden interaction paths.
+## 2024-04-23 - Full Keyboard Navigation Hints for Multi-Select Prompts
+**Learning:** `questionary.checkbox` prompts support advanced keyboard shortcuts like 'A to toggle all' and standard arrow key navigation. If these aren't explicitly mentioned in the `instruction` string, users may rely solely on Space and Enter, leading to slower interaction when managing many items.
+**Action:** Always include complete accessibility hints for multi-select prompts (e.g., `(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)`) to maximize feature discoverability and improve power-user efficiency.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,6 +1,7 @@
 ## 2024-05-24 - Consistent UI Text Styling in Rich Consoles
 **Learning:** Even when a project adopts a comprehensive terminal UI library like `rich`, straggling raw `print()` statements can easily break immersion and create an inconsistent user experience. In interactive CLI flows, unstyled text stands out poorly against styled elements (like panels or colored prompts).
 **Action:** When auditing CLI applications for UX, explicitly search for raw `print()` statements and replace them with the adopted styling library's output methods (e.g., `console.print()` in Rich) with appropriate semantic markup (e.g., `[dim cyan]`, `[yellow]`) to ensure a unified visual design language.
+
 ## 2024-05-25 - Prevent Layout Breakage with Long Filenames
 **Learning:** In terminal UIs using `rich` or `questionary` formatted strings, dynamic data like filenames can exceed expected column widths and completely break tabular alignments or wrap unpleasantly, making the UI look broken or amateurish.
 **Action:** Always defensively slice or truncate dynamic string data intended for fixed-width CLI columns (e.g., using an ellipsis `…` for filenames > 30 characters) to ensure layout stability.
@@ -24,6 +25,7 @@
 ## 2025-04-06 - Explicit Instruction Strings for questionary.confirm
 **Learning:** By default, `questionary.confirm` prompts do not display any keyboard shortcut instructions, leaving users unaware of options like `Ctrl+C` to cancel or `y/n` for explicit choices.
 **Action:** Explicitly provide an `instruction` string constant (e.g., `(y/n, Enter to confirm, Ctrl+C to cancel)`) to all `questionary.confirm` calls to surface hidden interaction paths.
+
 ## 2024-04-23 - Full Keyboard Navigation Hints for Multi-Select Prompts
 **Learning:** `questionary.checkbox` prompts support advanced keyboard shortcuts like 'A to toggle all' and standard arrow key navigation. If these aren't explicitly mentioned in the `instruction` string, users may rely solely on Space and Enter, leading to slower interaction when managing many items.
 **Action:** Always include complete accessibility hints for multi-select prompts (e.g., `(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)`) to maximize feature discoverability and improve power-user efficiency.

--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -22,9 +22,7 @@ from .main import console
 
 INSTR_SELECT = "(Use arrow keys to navigate, Enter to select, Ctrl+C to cancel)"
 INSTR_CONFIRM = "(y/n, Enter to confirm, Ctrl+C to cancel)"
-INSTR_MULTI_SELECT = (
-    "(Use Space to select/deselect, Enter to confirm, Ctrl+C to cancel)"
-)
+INSTR_MULTI_SELECT = "(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)"
 INSTR_CONFIRM = "(y/n, Enter to confirm, Ctrl+C to cancel)"
 
 


### PR DESCRIPTION
💡 What: Updated the `INSTR_MULTI_SELECT` instruction string in `src/image_converter/menu.py` to explicitly mention "arrow keys to navigate" and "A to toggle all" keyboard shortcuts.
🎯 Why: `questionary.checkbox` supports these advanced keyboard shortcuts, but without explicit instructions, users might not discover them. This makes the multi-select prompt more intuitive and efficient, especially for power users or when managing many items.
📸 Before/After: 
*   **Before:** `(Use Space to select/deselect, Enter to confirm, Ctrl+C to cancel)`
*   **After:** `(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)`
♿ Accessibility: Improves keyboard accessibility and feature discoverability for terminal users by making all available interaction paths explicit.

---
*PR created automatically by Jules for task [10783044802067218591](https://jules.google.com/task/10783044802067218591) started by @dealien*