### PR TITLE
📝 Scribe: Add Metadata API to documentation

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -12,3 +12,7 @@
 ## 2025-05-19 - Using string literals for type hinting missing parameters
 **Learning:** When adding type hints to undocumented functions without module-level imports, use string literals (e.g., `"numpy.ndarray"`) to avoid runtime `NameError` exceptions while satisfying the documentation builder (`mkdocs`). This was observed when adding hints to `_kovalevsky_scan` which caused `mkdocs build --strict` to fail until string literal hints were applied.
 **Action:** When acting as Scribe to add type hints to undocumented inner or private functions, evaluate if the type module is imported globally. If not, use string-based forward references (`"type"`) to add the hint safely.
+
+## 2025-05-19 - MkDocs Pygments Incompatibility
+**Learning:** Building MkDocs documentation with the `mkdocstrings-python` plugin can fail with an obfuscated `AttributeError: 'NoneType' object has no attribute 'replace'` within Python's built-in `html.escape` function. This crash is triggered by an upstream regression in Pygments version 2.20.0 when formatting syntax-highlighted code blocks with missing optional file names.
+**Action:** When adding or verifying MkDocs documentation for Python API modules, downgrade the `pygments` package to version `2.18.0` if build errors occur, and ensure all required type hints use string literals to avoid import crashes during documentation generation.

--- a/docs/api/metadata.md
+++ b/docs/api/metadata.md
@@ -1,0 +1,7 @@
+# Metadata API Reference
+
+This section provides documentation for the metadata handling and injection functions.
+
+## metadata
+
+::: image_converter.metadata

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,4 +29,5 @@ nav:
   - API Reference: 
       - Core: api/core.md
       - Filters: api/filters.md
+      - Metadata: api/metadata.md
       - Utilities & Menu: api/utilities.md


### PR DESCRIPTION
💡 What: Added a new `docs/api/metadata.md` page and included it in the `mkdocs.yml` navigation structure.
🎯 Why: The `image_converter.metadata` module handles critical privacy functionality (like viewing, exporting, and stripping EXIF tags), but its API methods were completely undocumented and hidden from the developer-facing MkDocs site. Adding this provides vital visibility into how these internal functions are exposed.
📖 Preview: The `Metadata API Reference` is now accessible in the sidebar, providing automatically generated documentation from the module's docstrings using `mkdocstrings`.

---
*PR created automatically by Jules for task [4220673955741869667](https://jules.google.com/task/4220673955741869667) started by @dealien*