### PR TITLE
🎨 Palette: Add keyboard shortcuts to text prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-04-23 - Full Keyboard Navigation Hints for Multi-Select Prompts
 **Learning:** `questionary.checkbox` prompts support advanced keyboard shortcuts like 'A to toggle all' and standard arrow key navigation. If these aren't explicitly mentioned in the `instruction` string, users may rely solely on Space and Enter, leading to slower interaction when managing many items.
 **Action:** Always include complete accessibility hints for multi-select prompts (e.g., `(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)`) to maximize feature discoverability and improve power-user efficiency.
+
+## 2025-05-18 - Missing Keyboard Instructions in Prompt Toolkit Input
+**Learning:** When migrating from `questionary.text().ask()` to custom `prompt_toolkit` implementations (like `_ask_text`) for advanced styling, default instruction texts are often lost. Users might not know they can use Ctrl+C to safely exit or Enter to accept default inputs without explicit guidance.
+**Action:** When using `prompt_toolkit`'s `PromptSession` (e.g., in `_ask_text`), explicitly append a styled instruction string (e.g., `(Enter to confirm, Ctrl+C to cancel)`) to the formatted message buffer to maintain UX consistency and keyboard shortcut discoverability.

--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -23,7 +23,7 @@ from .main import console
 INSTR_SELECT = "(Use arrow keys to navigate, Enter to select, Ctrl+C to cancel)"
 INSTR_CONFIRM = "(y/n, Enter to confirm, Ctrl+C to cancel)"
 INSTR_MULTI_SELECT = "(Use arrow keys to navigate, Space to select, Enter to confirm, A to toggle all, Ctrl+C to cancel)"
-INSTR_CONFIRM = "(y/n, Enter to confirm, Ctrl+C to cancel)"
+INSTR_TEXT = " (Enter to confirm, Ctrl+C to cancel)"
 
 
 # --- Helper Functions ---
@@ -34,6 +34,7 @@ _CUSTOM_STYLE = Style.from_dict(
         "question": "bold",  # Questionary default bold
         "answer": "#FF9D00 bold",  # Questionary default Orange
         "default": "fg:cyan",  # Our custom Cyan for default
+        "instruction": "fg:darkgray",  # Dim color for instructions
     }
 )
 
@@ -79,6 +80,7 @@ def _ask_text(
             formatted_msg.append((style_class, str(default_val)))
             formatted_msg.append(("", "]"))
 
+        formatted_msg.append(("class:instruction", INSTR_TEXT))
         formatted_msg.append(("class:question", ": "))
         return formatted_msg
 


### PR DESCRIPTION
💡 What: Added keyboard shortcut instructions `(Enter to confirm, Ctrl+C to cancel)` to the custom interactive text prompts `_ask_text`.
🎯 Why: Terminal users often do not know they can use Ctrl+C to safely exit the prompt toolkit, or Enter to accept default inputs. Making this explicit reduces anxiety and improves interaction discoverability.
📸 Before/After: Before: "Enter scale value: ". After: "Enter scale value (Enter to confirm, Ctrl+C to cancel): ".
♿ Accessibility: Enhances feature discoverability and provides clear text guidance for all keyboard users navigating text inputs.

---
*PR created automatically by Jules for task [4935186611943896309](https://jules.google.com/task/4935186611943896309) started by @dealien*