### PR TITLE
🎨 Palette: Add explicit exit option to main menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2025-05-18 - Missing Keyboard Instructions in Prompt Toolkit Input
 **Learning:** When migrating from `questionary.text().ask()` to custom `prompt_toolkit` implementations (like `_ask_text`) for advanced styling, default instruction texts are often lost. Users might not know they can use Ctrl+C to safely exit or Enter to accept default inputs without explicit guidance.
 **Action:** When using `prompt_toolkit`'s `PromptSession` (e.g., in `_ask_text`), explicitly append a styled instruction string (e.g., `(Enter to confirm, Ctrl+C to cancel)`) to the formatted message buffer to maintain UX consistency and keyboard shortcut discoverability.
+
+## 2025-03-04 - Explicit Exit Options in Interactive CLI Menus
+**Learning:** Adding a clear visual "Exit" option in the main operations menu avoids user frustration of having to rely purely on keyboard shortcuts (`Ctrl+C`) to quit the interactive UI safely.
+**Action:** Always provide explicit, discoverable exit paths in terminal menus alongside keyboard interrupt handlers.

--- a/src/image_converter/menu.py
+++ b/src/image_converter/menu.py
@@ -838,6 +838,7 @@ def select_manipulations(
             choices.append(
                 questionary.Choice("   ❌ Remove an Operation", value="REMOVE")
             )
+        choices.append(questionary.Choice("   🛑 Exit", value="EXIT"))
         choices.append(questionary.Separator(line=""))
 
         # Operations Tree Root
@@ -873,6 +874,9 @@ def select_manipulations(
         ).ask()
 
         if selection is None:  # C-c
+            raise KeyboardInterrupt
+
+        if selection == "EXIT":
             raise KeyboardInterrupt
 
         if selection == "PROCESS":

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -667,3 +667,10 @@ def test_select_images_no_images_reselect_cancel(
         mock_confirm.return_value.ask.return_value = None
         with pytest.raises(KeyboardInterrupt):
             menu.select_images()
+
+
+def test_select_manipulations_exit_selection(mock_questionary):
+    """Verifies KeyboardInterrupt is raised when 'EXIT' is selected."""
+    mock_questionary.select.return_value.ask.return_value = "EXIT"
+    with pytest.raises(KeyboardInterrupt):
+        menu.select_manipulations([])


### PR DESCRIPTION
💡 What: Added an explicit `🛑 Exit` choice to the main operations menu alongside the existing actions.
🎯 Why: Avoids user frustration of having to rely purely on keyboard shortcuts (`Ctrl+C`) to quit the interactive UI safely.
📸 Before/After: N/A (Terminal UI change)
♿ Accessibility: Provides a clear visual and keyboard-navigable exit path for users.

---
*PR created automatically by Jules for task [10821384233887955175](https://jules.google.com/task/10821384233887955175) started by @dealien*