### PR TITLE
🔬 Argus: Add test coverage for read-only image processing operations

### DIFF
--- a/tests/test_process_images_read_only.py
+++ b/tests/test_process_images_read_only.py
@@ -1,0 +1,54 @@
+import unittest
+import argparse
+from unittest.mock import patch, MagicMock
+from image_converter import processing
+
+
+class TestProcessImagesReadOnly(unittest.TestCase):
+    @patch("image_converter.processing.Progress")
+    @patch("image_converter.processing.Image.open")
+    def test_process_images_and_save_read_only_skips_save(
+        self, mock_image_open, mock_progress_class
+    ):
+        """Verifies that an image is not saved when only read-only operations are applied."""
+        # Setup mocks
+        mock_img = MagicMock()
+        mock_img.copy.return_value = mock_img
+        mock_image_open.return_value.__enter__.return_value = mock_img
+
+        mock_progress = MagicMock()
+        mock_progress_class.return_value.__enter__.return_value = mock_progress
+
+        # We need to simulate the progress bar adding a task to get an ID
+        mock_progress.add_task.return_value = 1
+
+        images_data = [("test_image.png", "test_path.png")]
+
+        ordered_operations = [{"dest": "view_metadata", "values": []}]
+
+        args = argparse.Namespace()
+        args.format = None
+        args.quality = None
+        args.resample = "bicubic"
+        args.threshold = 120
+
+        # Patch the handler directly
+        with patch(
+            "image_converter.processing.handle_view_metadata"
+        ) as mock_view_metadata:
+            mock_view_metadata.return_value = mock_img
+            processing.process_images_and_save(images_data, ordered_operations, args)
+
+        # Verify progress update was called with the right descriptions
+        update_calls = mock_progress.update.call_args_list
+        found_skipping = any(
+            "Skipping save, read-only" in str(call) for call in update_calls
+        )
+        self.assertTrue(found_skipping, "Should have logged 'Skipping save, read-only'")
+
+        # Verify img.save was not called
+        mock_img.save.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
💡 What: The core function `process_images_and_save` in `src/image_converter/processing.py` now has explicit test coverage for its read-only skipping behavior.
🎯 Why: This gap was a high priority as it handles core application logic for preventing accidental disk writes (e.g., when a user just wants to view metadata).
📊 Coverage: Lines 595-603 in `src/image_converter/processing.py` are now fully covered. 
🧪 Cases: The test simulates passing `view_metadata` to the processor, verifying the correct progress bar outputs are generated and that `Image.save()` is completely avoided.

---
*PR created automatically by Jules for task [5200837910398755333](https://jules.google.com/task/5200837910398755333) started by @dealien*